### PR TITLE
fix: namechanges

### DIFF
--- a/programs/capstone/src/instructions/withdraw.rs
+++ b/programs/capstone/src/instructions/withdraw.rs
@@ -1,7 +1,7 @@
 use anchor_lang::{prelude::*, system_program::{transfer, Transfer}};
 
 use crate::{
-    state::{Fundraiser},
+    state::Fundraiser,
     FundraiserError,
 };
 

--- a/programs/capstone/src/lib.rs
+++ b/programs/capstone/src/lib.rs
@@ -15,8 +15,6 @@ pub use constants::*;
 
 #[program]
 pub mod capstone {
-    use instruction::Withdraw;
-
     use super::*;
 
     pub fn initialize(ctx: Context<Initialize>, amount: u64, deadline: i64) -> Result<()> {


### PR DESCRIPTION
Merge to main. This fixes `anchor build` errors. It builds again.